### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "printenv2"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "bindgen",
  "clap 3.1.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printenv2"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 authors = [
     "Xinkai Chen <xinkai.chen@qq.com>",

--- a/README.md
+++ b/README.md
@@ -20,22 +20,34 @@ Installation
   * Arch Linux: `paru -S printenv2`
 * via Cargo: Run `cargo install printenv2` if you already have Rust development environment setup.
 
-Notes on remote mode
+Notes on Remote Mode
 --------------------
 
-`printenv2` comes with the ability to read environment variables of another running process. However, mileage varies depending on the operating system. 
+`printenv2` comes with the ability to read environment variables of another running process.
 
-The following table shows how each platform is supported.
+Basic usage: 
+```sh
+# Make sure you have privilege to inspect the target process.
+printenv2 --pid 1000
+```
 
-| Platform | Environment variables at startup                                                         | Environment variables in present                                                                                                                                                                                                                                                                                 |
-|----------|------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Linux    | `printenv2 --by-env-string /proc/<PID>/environ`.<br/>`sudo` for processes you don't own. | Use at your own risk.<br/>A debugger must be used to dump the memory where environment variables are stored. `printenv2 remote-env-string-dump` generates a shell script for that using `gdb`.<br/>`sh <(printenv2 remote-env-string-dump <PID>) \| printenv2 --by-env-string -`.<br/>`sudo` is likely required. |
-| Windows  | Unsupported.                                                                             | Use at your own risk.<br/>Using undocumented APIs to dump the memory where environment variables are stored.<br/>`printenv2 remote-env-string-dump <PID> \| printenv2 --by-env-string -`                                                                                                                         |
-| Other    | Unsupported.                                                                             | Unsupported.                                                                                                                                                                                                                                                                                                     |
+Platform-specifics:
+
+| Platform    | Environment variables at startup | Environment variables in present                                                                                                                                                                          |
+|-------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Linux       | `printenv2 --pid <PID>`          | Unsafe[^safety].<br/>`printenv2 --debugger-helper` generates a shell script for that using `gdb`.<br/>`sh <(printenv2 --debugger-helper=gdb) <PID> \  printenv2 --load -`.<br/>`sudo` is likely required. |
+| Windows     | Unsupported.                     | Unsafe[^safety].<br/>`printenv2 --pid <PID>`                                                                                                                                                              |
+| Unix (*BSD) | `printenv2 --pid <PID>`          | Unsafe[^safety].<br/>`printenv2 --debugger-helper` generates a shell script for that using `gdb`.<br/>`sh <(printenv2 --debugger-helper=gdb) <PID> \  printenv2 --load -`.<br/>`sudo` is likely required. |
+| macOS       | Unsupported.                     | Unsupported.                                                                                                                                                                                              |
+| Other       | Unsupported.                     | Unsupported.                                                                                                                                                                                              |
+
+[^safety]:
+* Safety: Be careful. These methods use a debugger or undocumented APIs.
 
 TODO
 ----
 - [ ] Remote mode on more OSes
+- [ ] Json output
 
 License
 -------

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,13 @@ fn main() {
 
     #[allow(clippy::match_same_arms)]
     match (unix.as_deref(), os.as_deref()) {
-        (Ok(_), Ok("linux")) => (),
-        (Ok(_), Ok("macos")) => (),
+        (Ok(_), Ok("linux")) => {
+            println!("cargo:rustc-cfg=debugger_helper");
+            println!("cargo:rustc-cfg=remote_env");
+        }
+        (Ok(_), Ok("macos")) => {
+            println!("cargo:rustc-cfg=debugger_helper");
+        }
         (Ok(_), _) => {
             println!("cargo:rerun-if-changed=src/kvm-wrapper.h");
 
@@ -24,7 +29,13 @@ fn main() {
                     .write_to_file(out_path.join("kvm-bindings.rs"))
                     .expect("Couldn't write kvm-bindings!");
                 println!("cargo:rustc-cfg=unix_kvm");
+                println!("cargo:rustc-cfg=remote_env");
             }
+
+            println!("cargo:rustc-cfg=debugger_helper");
+        }
+        (Err(_), Ok("windows")) => {
+            println!("cargo:rustc-cfg=remote_env");
         }
         _ => (),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+// #![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::nursery)]
@@ -7,89 +7,88 @@ use std::ffi::OsString;
 use std::fs::File;
 use std::io::{Read, Stdout, Write};
 
-use std::process::exit;
-
 mod args;
 mod definition;
 mod env;
 mod platform_ext;
 mod printer;
-#[cfg(target_family = "unix")]
+#[cfg(debugger_helper)]
 mod remote_debugger_helper;
-#[cfg(target_os = "linux")]
+#[cfg(all(remote_env, target_os = "linux"))]
 mod remote_linux_procfs;
-#[cfg(unix_kvm)]
+#[cfg(all(remote_env, unix_kvm))]
 mod remote_unix_kvm;
-#[cfg(target_family = "windows")]
+#[cfg(all(remote_env, target_family = "windows"))]
 mod remote_windows;
 
-use args::Commands;
 use definition::AppResult;
-use env::{parse_env_var_string, sort_pairs, RecordPair};
 use printer::Printer;
 
 fn main() -> AppResult<()> {
     let args = args::parse();
 
-    match args.command {
-        Some(Commands::RemoteEnvStringDump { pid }) => {
-            #[cfg(target_family = "unix")]
-            let output = { remote_debugger_helper::get_gdb_helper(pid) };
-
-            #[cfg(target_family = "windows")]
-            let output = { remote_windows::get_environment_string(pid)? };
-
-            colored::control::set_override(false);
-            print!("{}", output);
-
-            Ok(())
-        }
-        None => {
-            let mut printer = Printer::default();
-
-            // Override default printer behaviors
-            if args.null {
-                printer.null = args.null;
-            }
-
-            if !args.variables.is_empty() {
-                printer.variables = Some(&args.variables);
-            }
-
-            if let Some(color) = args.color {
-                printer.color = color;
-            }
-            if let Some(escape) = args.escape {
-                printer.escape = escape;
-            }
-
-            let mut results: Vec<RecordPair> = match args.by_env_string {
-                Some(path) => {
-                    let mut content = Vec::new();
-                    if path == OsString::from("-") {
-                        let stdin = std::io::stdin();
-                        let mut reader = stdin.lock();
-                        reader.read_to_end(&mut content)?;
-                    } else {
-                        let mut file = File::open(path)?;
-                        file.read_to_end(&mut content)?;
-                    }
-                    parse_env_var_string(&content)
-                }
-                None => env::get_record_pairs_for_current_process(),
-            };
-
-            if let Some(key_order) = args.key_order {
-                sort_pairs(key_order, &mut results);
-            }
-
-            let output = printer.print(&results)?;
-            Stdout::write(&mut std::io::stdout(), &output)?;
-
-            if output.is_empty() {
-                exit(1);
-            }
-            Ok(())
-        }
+    #[cfg(debugger_helper)]
+    if args.debugger_helper == Some(args::DebuggerHelper::Gdb) {
+        colored::control::set_override(false);
+        println!("{}", remote_debugger_helper::get_gdb_helper());
+        return Ok(());
     }
+
+    #[cfg(remote_env)]
+    let pid = args.pid;
+
+    #[cfg(not(remote_env))]
+    let pid: Option<u32> = None;
+
+    let env = {
+        let mut env = match (args.load, pid) {
+            (Some(path), None) => {
+                let mut content = Vec::new();
+                if path == OsString::from("-") {
+                    let stdin = std::io::stdin();
+                    let mut reader = stdin.lock();
+                    reader.read_to_end(&mut content)?;
+                } else {
+                    let mut file = File::open(path)?;
+                    file.read_to_end(&mut content)?;
+                }
+                env::Env::from(content)
+            }
+            #[cfg(remote_env)]
+            (None, Some(pid)) => env::Env::from(env::remote::get_environment_string(pid)?),
+            (None, None) => env::Env::new(),
+            _ => unreachable!(),
+        };
+
+        if let Some(key_order) = args.key_order {
+            env.sort_by_key(key_order);
+        }
+        env
+    };
+
+    let mut printer = Printer::default();
+
+    // Override default printer behaviors
+    if args.null {
+        printer.null = args.null;
+    }
+
+    if !args.variables.is_empty() {
+        printer.variables = Some(&args.variables);
+    }
+
+    if let Some(color) = args.color {
+        printer.color = color;
+    }
+    if let Some(escape) = args.escape {
+        printer.escape = escape;
+    }
+
+    let output = printer.print(&env)?;
+    Stdout::write(&mut std::io::stdout(), &output)?;
+
+    if output.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -120,25 +120,4 @@ mod tests {
             assert_eq!(Printer::escape(case.0), case.1);
         }
     }
-
-    #[cfg(remote_env)]
-    #[test]
-    fn null_mode() {
-        use crate::args::ColorMode;
-        use crate::env;
-
-        let printer = Printer {
-            null: true,
-            color: ColorMode::Never, // args.rs would set color to never if null is enabled
-            ..Printer::default()
-        };
-
-        let actual = {
-            let env_obj = env::Env::new();
-            printer.print(&env_obj).unwrap()
-        };
-
-        let expected = env::remote::get_environment_string(std::process::id()).unwrap();
-        assert_eq!(actual, expected);
-    }
 }

--- a/src/remote_debugger_helper.rs
+++ b/src/remote_debugger_helper.rs
@@ -1,12 +1,11 @@
-pub fn get_gdb_helper(pid: u32) -> String {
-    format!(
-        r##"#!/bin/sh
+pub fn get_gdb_helper() -> String {
+    r##"#!/bin/sh
 
 set -eu
 
 OUTPUT=$(mktemp --quiet)
 
-cat << EOF | gdb --pid={}
+cat << EOF | gdb --pid="$1"
 set pagination off
 set variable \$env = (char**) __environ
 set variable \$i=0
@@ -23,7 +22,6 @@ EOF
 
 cat "$OUTPUT"
 rm "$OUTPUT"
-"##,
-        pid
-    )
+"##
+    .to_string()
 }

--- a/src/remote_linux_procfs.rs
+++ b/src/remote_linux_procfs.rs
@@ -3,24 +3,9 @@ use std::io::Read;
 
 use crate::definition::AppResult;
 
-#[allow(dead_code)]
 pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     let mut file = File::open(format!("/proc/{}/environ", pid))?;
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer)?;
     Ok(buffer)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::get_environment_string;
-    use crate::env::{get_record_pairs_for_current_process, parse_env_var_string};
-
-    #[test]
-    fn test_get_environment_string() {
-        let env_string = get_environment_string(std::process::id()).unwrap();
-        let actual = parse_env_var_string(&env_string);
-        let expected = get_record_pairs_for_current_process();
-        assert_eq!(actual, expected);
-    }
 }

--- a/src/remote_unix_kvm.rs
+++ b/src/remote_unix_kvm.rs
@@ -97,23 +97,8 @@ mod oxidation {
     }
 }
 
-#[allow(dead_code)]
 pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     let kvm = oxidation::Kvm::try_new()?;
     let proc = kvm.get_proc(pid)?;
     kvm.get_env(proc)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::get_environment_string;
-    use crate::env::{get_record_pairs_for_current_process, parse_env_var_string};
-
-    #[test]
-    fn test_get_environment_string() {
-        let env_string = get_environment_string(std::process::id()).unwrap();
-        let actual = parse_env_var_string(&env_string);
-        let expected = get_record_pairs_for_current_process();
-        assert_eq!(actual, expected);
-    }
 }

--- a/src/remote_windows.rs
+++ b/src/remote_windows.rs
@@ -322,7 +322,7 @@ pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     let cap = (user_process_parameters.EnvironmentSize / 2) as usize;
 
     let environment = {
-        let mut out = vec![0u16; cap];
+        let mut out = vec![0u16; cap - 1];
 
         oxidation::read_process_memory(
             process_handle.clone(),

--- a/src/remote_windows.rs
+++ b/src/remote_windows.rs
@@ -267,7 +267,7 @@ mod oxidation {
     }
 }
 
-pub fn get_environment_string(pid: u32) -> AppResult<String> {
+pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     let current_process = oxidation::get_current_process();
 
     let token_handle =
@@ -337,19 +337,5 @@ pub fn get_environment_string(pid: u32) -> AppResult<String> {
     drop(token_handle);
     drop(process_handle);
 
-    Ok(String::from_utf16(&environment)?)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::get_environment_string;
-    use crate::env::{get_record_pairs_for_current_process, parse_env_var_string};
-
-    #[test]
-    fn test_get_environment_string() {
-        let env_string = get_environment_string(std::process::id()).unwrap();
-        let actual = parse_env_var_string(env_string.as_bytes());
-        let expected = get_record_pairs_for_current_process();
-        assert_eq!(actual, expected);
-    }
+    Ok(String::from_utf16(&environment)?.into())
 }


### PR DESCRIPTION
1. Add "--pid" for reading environment variables from a remote process.
2. Rename "--by_env_string" to "--load".
3. Add "--debugger-helper" for generating a debugging script.
4. Use cfg(remote_env) to mark the availability for reading from remote processes.
5. Better coding style by using traits and impls.