### PR TITLE
Release 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "printenv2"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bindgen",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,14 +30,14 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 2.34.0",
+ "clap",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -94,41 +85,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
- "strsim 0.10.0",
+ "once_cell",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -139,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -279,6 +255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,7 +277,7 @@ name = "printenv2"
 version = "0.0.3"
 dependencies = [
  "bindgen",
- "clap 3.1.12",
+ "clap",
  "colored",
  "windows",
 ]
@@ -373,12 +355,6 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -405,36 +381,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -486,9 +441,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
+checksum = "0c47017195a790490df51a3e27f669a7d4f285920d90d03ef970c5d886ef0af1"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -499,30 +454,30 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "b12add87e2fb192fff3f4f7e4342b3694785d79f3a64e2c20d5ceb5ccbcfc3cd"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "4c98f2db372c23965c5e0f43896a8f0316dc0fbe48d1aa65bea9bdd295d43c15"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "cdf0569be0f2863ab6a12a6ba841fcfa7d107cbc7545a3ebd57685330db0a3ff"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "905858262c8380a36f32cb8c1990d7e7c3b7a8170e58ed9a98ca6d940b7ea9f1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "890c3c6341d441ffb38f705f47196e3665dc6dd79f6d72fa185d937326730561"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printenv2"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 authors = [
     "Xinkai Chen <xinkai.chen@qq.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ build = "build.rs"
 
 [dependencies]
 colored = { version = "2" }
-clap = { version = "3.1.12", features = ["derive"] }
+clap = { version = "3.2.16", features = ["derive"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-windows = { version = "0.36.1", features = [
+windows = { version = "0.38", features = [
     "alloc",
     "Win32_System_Threading",
     "Win32_Foundation",
@@ -32,7 +32,7 @@ windows = { version = "0.36.1", features = [
 ] }
 
 [build-dependencies]
-bindgen = { version = "0.59.2" }
+bindgen = { version = "0.60.1" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ bindgen = { version = "0.60.1" }
 opt-level = 3
 lto = true
 panic = "abort"
+strip = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ Platform-specifics:
 | Linux       | `printenv2 --pid <PID>`          | Unsafe[^1].<br/>`printenv2 --debugger-helper` generates a shell script for that using `gdb`.<br/>`sh <(printenv2 --debugger-helper=gdb) <PID> \| printenv2 --load -`.<br/>`sudo` is likely required. |
 | Windows     | Unsupported.                     | Unsafe[^1].<br/>`printenv2 --pid <PID>`                                                                                                                                                              |
 | Unix (*BSD) | `printenv2 --pid <PID>`          | Unsafe[^1].<br/>`printenv2 --debugger-helper` generates a shell script for that using `gdb`.<br/>`sh <(printenv2 --debugger-helper=gdb) <PID> \| printenv2 --load -`.<br/>`sudo` is likely required. |
-| macOS       | Unsupported.                     | Unsupported.                                                                                                                                                                                         |
+| macOS       | `printenv2 --pid <PID>`          | Unsupported.                                                                                                                                                                                         |
 | Other       | Unsupported.                     | Unsupported.                                                                                                                                                                                         |
 
 [^1]: Be careful. These methods use a debugger or undocumented APIs.
 
 TODO
 ----
-- [ ] Remote mode on more OSes
 - [ ] Json output
 
 License

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,21 @@ fn main() {
             println!("cargo:rustc-cfg=remote_env");
         }
         (Ok(_), Ok("macos")) => {
+            println!("cargo:rerun-if-changed=src/apple-sysctl-wrapper.h");
+
+            if let Ok(sysctl_bindings) = bindgen::Builder::default()
+                .header("src/apple-sysctl-wrapper.h")
+                .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+                .generate()
+            {
+                let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+                sysctl_bindings
+                    .write_to_file(out_path.join("apple-sysctl-bindings.rs"))
+                    .expect("Couldn't write apple-sysctl-bindings!");
+                println!("cargo:rustc-cfg=unix_apple_sysctl");
+                println!("cargo:rustc-cfg=remote_env");
+            }
+
             println!("cargo:rustc-cfg=debugger_helper");
         }
         (Ok(_), _) => {

--- a/src/apple-sysctl-wrapper.h
+++ b/src/apple-sysctl-wrapper.h
@@ -1,0 +1,4 @@
+// macOS
+
+#include <sys/types.h>
+#include <sys/sysctl.h>

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -9,6 +9,12 @@ pub enum AppError {
 
     #[cfg(unix_kvm)]
     UnixErrorString(std::ffi::CString),
+
+    #[cfg(unix_apple_sysctl)]
+    TryFromIntError(std::num::TryFromIntError),
+
+    #[cfg(unix_apple_sysctl)]
+    TryFromSliceError(std::array::TryFromSliceError),
 }
 
 pub type AppResult<T> = Result<T, AppError>;
@@ -43,5 +49,19 @@ impl From<windows::core::Error> for AppError {
 impl From<std::ffi::CString> for AppError {
     fn from(err_str: std::ffi::CString) -> Self {
         Self::UnixErrorString(err_str)
+    }
+}
+
+#[cfg(unix_apple_sysctl)]
+impl From<std::num::TryFromIntError> for AppError {
+    fn from(err: std::num::TryFromIntError) -> Self {
+        Self::TryFromIntError(err)
+    }
+}
+
+#[cfg(unix_apple_sysctl)]
+impl From<std::array::TryFromSliceError> for AppError {
+    fn from(err: std::array::TryFromSliceError) -> Self {
+        Self::TryFromSliceError(err)
     }
 }

--- a/src/definition.rs
+++ b/src/definition.rs
@@ -1,12 +1,13 @@
 #[derive(Debug)]
 pub enum AppError {
     Utf8Error(std::str::Utf8Error),
-    Utf16Error(std::string::FromUtf16Error),
     StdIo(std::io::Error),
     #[cfg(windows)]
     WindowsCore(windows::core::Error),
+    #[cfg(windows)]
+    Utf16Error(std::string::FromUtf16Error),
 
-    #[cfg(unix)]
+    #[cfg(unix_kvm)]
     UnixErrorString(std::ffi::CString),
 }
 
@@ -18,6 +19,7 @@ impl From<std::str::Utf8Error> for AppError {
     }
 }
 
+#[cfg(windows)]
 impl From<std::string::FromUtf16Error> for AppError {
     fn from(err: std::string::FromUtf16Error) -> Self {
         Self::Utf16Error(err)
@@ -37,7 +39,7 @@ impl From<windows::core::Error> for AppError {
     }
 }
 
-#[cfg(unix)]
+#[cfg(unix_kvm)]
 impl From<std::ffi::CString> for AppError {
     fn from(err_str: std::ffi::CString) -> Self {
         Self::UnixErrorString(err_str)

--- a/src/env.rs
+++ b/src/env.rs
@@ -63,6 +63,11 @@ pub mod remote {
         {
             crate::remote_windows::get_environment_string(pid)
         }
+
+        #[cfg(unix_apple_sysctl)]
+        {
+            crate::remote_apple_sysctl::get_environment_string(pid)
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::pedantic)]
 #![deny(clippy::nursery)]
 #![deny(clippy::cargo)]
+
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{Read, Stdout, Write};
@@ -12,6 +13,8 @@ mod definition;
 mod env;
 mod platform_ext;
 mod printer;
+#[cfg(unix_apple_sysctl)]
+mod remote_apple_sysctl;
 #[cfg(debugger_helper)]
 mod remote_debugger_helper;
 #[cfg(all(remote_env, target_os = "linux"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::nursery)]
@@ -16,7 +16,7 @@ mod printer;
 mod remote_debugger_helper;
 #[cfg(all(remote_env, target_os = "linux"))]
 mod remote_linux_procfs;
-#[cfg(all(remote_env, unix_kvm))]
+#[cfg(unix_kvm)]
 mod remote_unix_kvm;
 #[cfg(all(remote_env, target_family = "windows"))]
 mod remote_windows;

--- a/src/remote_apple_sysctl.rs
+++ b/src/remote_apple_sysctl.rs
@@ -1,0 +1,121 @@
+use crate::AppResult;
+use std::mem::size_of;
+
+#[allow(warnings)]
+#[allow(clippy::all)]
+#[allow(clippy::pedantic)]
+#[allow(clippy::nursery)]
+#[allow(unaligned_references)]
+mod apple_sysctl_bindings {
+    include!(concat!(env!("OUT_DIR"), "/apple-sysctl-bindings.rs"));
+}
+mod oxidation {
+    use super::apple_sysctl_bindings::{sysctl, CTL_KERN, KERN_ARGMAX, KERN_PROCARGS2};
+    use super::{size_of, AppResult};
+
+    use std::ptr::null_mut;
+
+    pub fn argmax() -> AppResult<i32> {
+        // Get max process args size.
+        let mut mib = [CTL_KERN, KERN_ARGMAX];
+        let mut maxarg: i32 = 0;
+        let mut size: u64 = size_of::<i32>().try_into()?;
+        let ret = unsafe {
+            sysctl(
+                mib.as_mut_ptr().cast::<i32>(),
+                2,
+                std::ptr::addr_of_mut!(maxarg).cast::<std::ffi::c_void>(),
+                &mut size,
+                null_mut(),
+                0,
+            )
+        };
+        if ret == 0 {
+            Ok(maxarg)
+        } else {
+            Err(std::io::Error::last_os_error().into())
+        }
+    }
+
+    pub fn procargs2(pid: u32, buffer: &mut Vec<u8>) -> AppResult<()> {
+        let mut mib = [CTL_KERN, KERN_PROCARGS2, pid];
+        let mut size: u64 = buffer.capacity().try_into()?;
+        let err = unsafe {
+            sysctl(
+                mib.as_mut_ptr().cast::<i32>(),
+                3,
+                buffer.as_mut_ptr().cast::<std::ffi::c_void>(),
+                &mut size,
+                null_mut(),
+                0,
+            )
+        };
+        if err == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error().into())
+        }
+    }
+}
+
+struct BufferWalker {
+    data: Vec<u8>,
+    cursor: usize,
+}
+
+impl BufferWalker {
+    fn next_string_with_nul(&mut self) -> &[u8] {
+        // Always starts at a non-null
+        let start = self.cursor;
+        let end = self.data[self.cursor..]
+            .iter()
+            .position(|c| *c == 0)
+            .expect("finds end of NUL")
+            + 1
+            + start;
+        self.cursor = self.data[end..]
+            .iter()
+            .position(|c| *c != 0)
+            .expect("finds start")
+            + end;
+        &self.data[start..end]
+    }
+
+    fn next_string_with_nulnul(&mut self) -> &[u8] {
+        let start = self.cursor;
+        let end = self.data[self.cursor..]
+            .windows(2)
+            .position(|cc| cc == [0, 0])
+            .expect("finds NULNUL")
+            + 1
+            + start;
+        self.cursor = self.data[end..]
+            .iter()
+            .position(|c| *c != 0)
+            .expect("finds start")
+            + end;
+        &self.data[start..end]
+    }
+}
+
+pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
+    let argmax = oxidation::argmax()?;
+    let mut buffer = vec![0; argmax.try_into()?];
+    oxidation::procargs2(pid, &mut buffer)?;
+
+    let arg_count = u32::from_ne_bytes(buffer[0..size_of::<u32>()].try_into()?);
+
+    let mut bw = BufferWalker {
+        data: buffer,
+        cursor: size_of::<u32>(),
+    };
+    bw.next_string_with_nul();
+
+    for _ in 0..arg_count {
+        bw.next_string_with_nul();
+    }
+
+    let slice = bw.next_string_with_nulnul();
+
+    Ok(slice.into())
+}

--- a/src/remote_windows.rs
+++ b/src/remote_windows.rs
@@ -322,7 +322,7 @@ pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     let cap = (user_process_parameters.EnvironmentSize / 2) as usize;
 
     let environment = {
-        let mut out = vec![0u16; cap - 1];
+        let mut out = vec![0u16; cap];
 
         oxidation::read_process_memory(
             process_handle.clone(),
@@ -337,5 +337,11 @@ pub fn get_environment_string(pid: u32) -> AppResult<Vec<u8>> {
     drop(token_handle);
     drop(process_handle);
 
-    Ok(String::from_utf16(&environment)?.into())
+    let result = {
+        let mut v: Vec<u8> = String::from_utf16(&environment)?.into();
+        v.truncate(v.len() - 1);
+        v
+    };
+
+    Ok(result)
 }


### PR DESCRIPTION
Bump version to 0.0.4

1. Support remote mode on macOS.
2. Upgrade dependencies.
3. Build optimization.
4. Fix STATUS_HEAP_CORRUPTION on Windows